### PR TITLE
Arrange info sections horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,17 @@
         .slideshow { position: relative; height: 455px; width: 1288px; flex-basis: 100%; overflow: hidden; margin: 1rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); background:#000; }
         .slides img { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; opacity: 0; transition: opacity 1s ease-in-out; }
         .slides img.active { opacity: 1; }
-        .info-block { display: flex; align-items: flex-start; flex-wrap: wrap; }
-        .right-column { display: flex; flex-direction: column; margin-left: auto; }
+        .info-block {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .details-row {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            width: 100%;
+        }
     </style>
 </head>
 <body>
@@ -130,15 +139,27 @@
                         <section className="slideshow">
                             <SlideShow />
                         </section>
-                        <section className="announcements">
-                            <h2>Annoucements</h2>
-                            <ul>
-                                <li>Please arrive 15 minutes before your shift.</li>
-                                <li>Check in at the reception desk upon arrival.</li>
-                                <li>Contact your team lead with any questions.</li>
-                            </ul>
-                        </section>
-                        <div className="right-column">
+                        <div className="details-row">
+                            <section className="announcements">
+                                <h2>Annoucements</h2>
+                                <ul>
+                                    <li>Please arrive 15 minutes before your shift.</li>
+                                    <li>Check in at the reception desk upon arrival.</li>
+                                    <li>Contact your team lead with any questions.</li>
+                                </ul>
+                            </section>
+                            <section className="services">
+                                <h3>Services Provided</h3>
+                                <ul>
+                                    <li>Registration</li>
+                                    <li>Guided tour</li>
+                                    <li>Information Packet</li>
+                                </ul>
+                            </section>
+                            <section className="about">
+                                <h3>About</h3>
+                                <p>I am a volunteer coordinating schedules for guest reception at Jalsa USA 2025. This site outlines how I manage communications with confirmed volunteers.</p>
+                            </section>
                             <section className="contact-info">
                                 <h3>Director of Guest Reception</h3>
                                 <p>Ahmed Khan</p>
@@ -146,18 +167,7 @@
                                 <p>Phone: 765-437-2876</p>
                                 <p>Location: Richmond, VA</p>
                             </section>
-                            <section className="about">
-                                <h3>About</h3>
-                                <p>I am a volunteer coordinating schedules for guest reception at Jalsa USA 2025. This site outlines how I manage communications with confirmed volunteers.</p>
-                            </section>
-                        <section className="services">
-                            <h3>Services Provided</h3>
-                            <ul>
-                                <li>Registration</li>
-                                <li>Guided tour</li>
-                                <li>Information Packet</li>
-                            </ul>
-                        </section>
+                        </div>
                     </div>
                 </div>
                 </div>


### PR DESCRIPTION
## Summary
- convert `.info-block` to column layout and add `.details-row`
- place announcements, services, about, and contact info in a horizontal row

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c324404648329864d1a411dde79ce