### PR TITLE
Add privacy and terms pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,8 @@
         <div class="links">
             <a href="https://jalsaschedulesystem.onrender.com/" target="_blank" rel="noopener noreferrer">Login / Register</a>
             <a href="https://jalsaschedulesystem.onrender.com/consent.html" target="_blank" rel="noopener noreferrer">Consent Page</a>
+            <a href="privacy.html">Privacy Policy</a>
+            <a href="terms.html">Terms of Use</a>
         </div>
     </header>
     <div class="info-block">

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy</title>
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p>This site collects only the information necessary to coordinate volunteer schedules and communicate event details. We do not share this data with third parties, and it is used solely for Jalsa Salana USA activities.</p>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Use</title>
+</head>
+<body>
+    <h1>Terms of Use</h1>
+    <p>By accessing this site you agree to provide accurate information and use the volunteer communication tools responsibly. Misuse of the system may result in removal from the volunteer program.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `privacy.html` and `terms.html`
- link to the new privacy and terms pages from the header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d61eb69948329976f7d2e2198d404