### PR TITLE
Fix overlapping header links

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,20 +17,19 @@
             position: relative;
             display: flex;
             align-items: center;
+            justify-content: center;
             background: #002855;
             color: white;
             padding: 1rem;
         }
         .title {
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 100%;
-            text-align: center;
             font-size: 2.6rem;
-            pointer-events: none;
+            text-align: center;
         }
-        header .links { margin-left: auto; }
+        header .links {
+            position: absolute;
+            right: 1rem;
+        }
         header .links a { color: white; margin-left: 1rem; text-decoration: none; font-weight: bold; }
         header .links a:hover { text-decoration: underline; }
         .purpose,


### PR DESCRIPTION
## Summary
- prevent page header links from colliding with the title text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5bc3c39c8329a563766555b8041d